### PR TITLE
Also build for new npm versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
         update-types: 
           - "version-update:semver-major"
 
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - Dockerfile
+      - package.json
 
 jobs:
   docker:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "npm": "^9.4.1"
+  }
+}


### PR DESCRIPTION
Add a package.lock that is watched by Dependabot and trigger new builds of the Docker image when there is a new npm version