### PR TITLE
Add docker/metadata-action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,18 +1,27 @@
 name: Docker CI
 
 on:
-  push:
+  release:
+    types:
+      - published
+
+  pull_request:
     branches:
       - main
-    paths:
-      - Dockerfile
-      - package.json
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.3.0
+      - uses: docker/metadata-action@v4.3.0
+        id: metadata
+        with:
+          images: |
+            ghcr.io/matijs/node
+          tags: |
+            type=semver,pattern={{version}}
+      - uses: docker/setup-qemu-action@v2.1.0
       - uses: docker/setup-buildx-action@v2.4.0
       - uses: docker/login-action@v2.1.0
         with:
@@ -23,6 +32,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/matijs/node:latest
+          push: ${{ github.event_name == 'release' }}
+          tags: ${{ steps.metadata.outputs.tags }}
 


### PR DESCRIPTION
Always build a new image, but only push it when it's released